### PR TITLE
Removes mobile number numeric validation to keep consistency

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -154,37 +154,23 @@ class AuthController extends BaseAuthController
         ]);
 
         try {
-            $code = $request->input('code');
-            $mobile = ltrim($request->input('mobile'), '0');
-            $number = '(+'.$code.') '.$mobile;
+            $code = $request->code;
+            $mobile = ltrim($request->mobile, '0');
+            $formatted_mobile = sprintf('(+%s) %s', $code, $mobile);
 
-            $result = $this->sendForReOtp($mobile, $code, $request->input('type'));
+            $result = $this->sendForReOtp($mobile, $code, $request->type);
 
-            switch ($request->input('type')) {
-                case 'text':
-                    $array = json_decode($result, true);
-                    $response = ['type' => 'success',
-                        'message' => 'OTP has been resent to '.$number.'.Please Enter the OTP to login!!', ];
+            $response = ['type' => 'success'];
+            $response['message'] = match ($request->type) {
+                'text' => 'OTP has been resent to '.$formatted_mobile.'.Please Enter the OTP to login!!',
+                default => 'Voice call has been sent to '.$formatted_mobile.'.Please Enter the OTP received on the call to login!!',
+            };
 
-                    break;
-
-                case 'voice':
-                    $array = json_decode($result, true);
-                    $response = ['type' => 'success',
-                        'message' => 'Voice call has been sent to '.$number.'.Please Enter the OTP received on the call to login!!', ];
-                    break;
-
-                default:
-                    $response = ['type' => 'success',
-                        'message' => 'Voice call has been sent to '.$number.'.Please Enter the OTP received on the call to login!!', ];
-                    break;
-            }
-
-            return response()->json($response);
-        } catch (\Exception $ex) {
-            $result = [$ex->getMessage()];
-
-            return response()->json(compact('result'), 500);
+            return $response;
+        } catch (\Exception $e) {
+            return response()->json([
+                'response' => $e->getMessage()
+            ], 500);
         }
     }
 

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -169,7 +169,7 @@ class AuthController extends BaseAuthController
             return $response;
         } catch (\Exception $e) {
             return response()->json([
-                'response' => $e->getMessage()
+                'response' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -156,7 +156,6 @@ class AuthController extends BaseAuthController
         try {
             $code = $request->input('code');
             $mobile = ltrim($request->input('mobile'), '0');
-            $otp = $request->input('otp');
             $number = '(+'.$code.') '.$mobile;
 
             $result = $this->sendForReOtp($mobile, $code, $request->input('type'));
@@ -176,7 +175,6 @@ class AuthController extends BaseAuthController
                     break;
 
                 default:
-                    $array = json_decode($result, true);
                     $response = ['type' => 'success',
                         'message' => 'Voice call has been sent to '.$number.'.Please Enter the OTP received on the call to login!!', ];
                     break;

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -150,7 +150,7 @@ class AuthController extends BaseAuthController
     {
         $this->validate($request, [
             'code' => 'required|numeric',
-            'mobile' => 'required|numeric',
+            'mobile' => 'required',
         ]);
 
         try {

--- a/app/Http/Controllers/Auth/BaseAuthController.php
+++ b/app/Http/Controllers/Auth/BaseAuthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\ApiKey;
+use GuzzleHttp\Client;
 use App\Http\Controllers\Controller;
 use App\Model\Common\Country;
 use App\Model\Common\Setting;
@@ -75,20 +76,21 @@ class BaseAuthController extends Controller
      */
     public function sendForReOtp($mobile, $code, $type)
     {
-        $client = new \GuzzleHttp\Client();
-        $number = $code.$mobile;
-        $key = ApiKey::where('id', 1)->value('msg91_auth_key');
+        $response = (new Client())->request('GET', 'https://api.msg91.com/api/v5/otp/retry', [
+            'query' => [
+                'authkey'    => ApiKey::first()->msg91_auth_key, 
+                'mobile'     => "{$code}{$mobile}", 
+                'retrytype'  => $type
+            ],
+        ])
+        ->getBody()
+        ->getContents();
 
-        $response = $client->request('GET', 'https://api.msg91.com/api/v5/otp/retry', [
-            'query' => ['authkey' => $key, 'mobile' => $number, 'retrytype' => $type],
-        ]);
-        $send = $response->getBody()->getContents();
-        $array = json_decode($send, true);
-        if ($array['type'] == 'error') {
-            throw new \Exception($array['message']);
-        }
+        $response_decoded = json_decode($response, true);
 
-        return $array['type'];
+        return ($response_decoded['type'] == 'error') ? 
+            throw new \Exception($response_decoded['message']) : 
+            $response_decoded['type'];
     }
 
     /**

--- a/app/Http/Controllers/Auth/BaseAuthController.php
+++ b/app/Http/Controllers/Auth/BaseAuthController.php
@@ -78,8 +78,8 @@ class BaseAuthController extends Controller
     {
         $response = (new Client())->request('GET', 'https://api.msg91.com/api/v5/otp/retry', [
             'query' => [
-                'authkey'    => ApiKey::first()->msg91_auth_key, 
-                'mobile'     => "{$code}{$mobile}", 
+                'authkey'    => ApiKey::first()->msg91_auth_key,
+                'mobile'     => "{$code}{$mobile}",
                 'retrytype'  => $type,
             ],
         ])
@@ -88,7 +88,7 @@ class BaseAuthController extends Controller
 
         $response_decoded = json_decode($response, true);
 
-        return ($response_decoded['type'] == 'error') ? 
+        return ($response_decoded['type'] == 'error') ?
             throw new \Exception($response_decoded['message']) :
             $response_decoded['type'];
     }

--- a/app/Http/Controllers/Auth/BaseAuthController.php
+++ b/app/Http/Controllers/Auth/BaseAuthController.php
@@ -3,13 +3,13 @@
 namespace App\Http\Controllers\Auth;
 
 use App\ApiKey;
-use GuzzleHttp\Client;
 use App\Http\Controllers\Controller;
 use App\Model\Common\Country;
 use App\Model\Common\Setting;
 use App\Model\Common\StatusSetting;
 use App\Model\User\AccountActivate;
 use App\User;
+use GuzzleHttp\Client;
 use Illuminate\Http\Request;
 use Symfony\Component\Mime\Email;
 
@@ -80,7 +80,7 @@ class BaseAuthController extends Controller
             'query' => [
                 'authkey'    => ApiKey::first()->msg91_auth_key, 
                 'mobile'     => "{$code}{$mobile}", 
-                'retrytype'  => $type
+                'retrytype'  => $type,
             ],
         ])
         ->getBody()
@@ -89,7 +89,7 @@ class BaseAuthController extends Controller
         $response_decoded = json_decode($response, true);
 
         return ($response_decoded['type'] == 'error') ? 
-            throw new \Exception($response_decoded['message']) : 
+            throw new \Exception($response_decoded['message']) :
             $response_decoded['type'];
     }
 


### PR DESCRIPTION
resolves #1984 

There are several ways we could get this exception for example:

An empty string is _NOT_ numeric 
Space between mobile number is _NOT_ numeric
Contains any special characters in mobile number is _NOT_ numeric

**In php 7**
'123456789 ' is _NOT_ numeric

Generally It is not advisable to use numeric in phone numbers.