### PR TITLE
Removes mobile number numeric validation to keep consistency

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -148,7 +148,7 @@ class AuthController extends BaseAuthController
 
     public function retryOTP(Request $request)
     {
-         $this->validate($request, [
+        $this->validate($request, [
             'code' => 'required|numeric',
             'mobile' => 'required',
         ]);

--- a/app/Http/Controllers/Auth/BaseAuthController.php
+++ b/app/Http/Controllers/Auth/BaseAuthController.php
@@ -10,7 +10,6 @@ use App\Model\Common\StatusSetting;
 use App\Model\User\AccountActivate;
 use App\User;
 use Illuminate\Http\Request;
-use GuzzleHttp\Client;
 use Symfony\Component\Mime\Email;
 
 class BaseAuthController extends Controller
@@ -52,7 +51,7 @@ class BaseAuthController extends Controller
      */
     public static function sendOtp($mobile, $code)
     {
-         $client = new \GuzzleHttp\Client();
+        $client = new \GuzzleHttp\Client();
         $number = $code.$mobile;
         $key = ApiKey::where('id', 1)->select('msg91_auth_key', 'msg91_sender')->first();
 

--- a/app/Http/Controllers/Auth/BaseAuthController.php
+++ b/app/Http/Controllers/Auth/BaseAuthController.php
@@ -51,23 +51,21 @@ class BaseAuthController extends Controller
      */
     public static function sendOtp($mobile, $code)
     {
-        $client = new \GuzzleHttp\Client();
-        $number = $code.$mobile;
-        $key = ApiKey::where('id', 1)->select('msg91_auth_key', 'msg91_sender')->first();
+       $response = (new Client())->request('GET', 'https://api.msg91.com/api/v5/otp/retry', [
+            'query' => [
+                'authkey'    => ApiKey::first()->msg91_auth_key,
+                'mobile'     => "{$code}{$mobile}",
+                'retrytype'  => $type,
+            ],
+        ])
+        ->getBody()
+        ->getContents();
 
-        $response = $client->request('GET', 'https://api.msg91.com/api/v5/otp', [
-            'query' => ['authkey' => $key->msg91_auth_key, 'mobiles' => $number, 'sender' => $key->msg91_sender, 'template_id' => '60979666dc49883cda77961b', 'OPT' => '', 'form_params' => ['var' => '']],
+        $response_decoded = json_decode($response, true);
 
-            // 'query' => ['authkey' => $key->msg91_auth_key, 'mobile' => $number, 'sender'=>$key->msg91_sender],
-        ]);
-
-        $send = $response->getBody()->getContents();
-        $array = json_decode($send, true);
-        if ($array['type'] == 'error') {
-            throw new \Exception($array['message']);
-        }
-
-        return $array['type'];
+        return ($response_decoded['type'] == 'error') ?
+            throw new \Exception($response_decoded['message']) :
+            $response_decoded['type'];
     }
 
     /**

--- a/resources/views/themes/default1/front/auth/login-register.blade.php
+++ b/resources/views/themes/default1/front/auth/login-register.blade.php
@@ -722,6 +722,9 @@ Sign in or Register
                     $('#error2').hide();
                     var result =  '<div class="alert alert-success"> <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong><i class="far fa-thumbs-up"></i>Well Done! </strong>'+response.message+'!</div>';
                     $('#alertMessage3').html(result+ ".");
+                      setTimeout(function(){
+                        $('#alertMessage3').hide();
+                        }, 3000);
                 },
                 error: function (ex) {
                     $("#resendOTP").attr('disabled',false);
@@ -765,6 +768,9 @@ Sign in or Register
                     $('#error2').hide();
                     var result =  '<div class="alert alert-success"> <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong><i class="far fa-thumbs-up"></i>Well Done! </strong>'+response.message+'!</div>';
                     $('#alertMessage3').html(result+ ".");
+                     setTimeout(function(){
+                        $('#alertMessage3').hide();
+                        }, 3000);
                 },
                 error: function (ex) {
                     $("#voiceOTP").attr('disabled',false);
@@ -911,6 +917,15 @@ Sign in or Register
                             $("#sendOtp").html("Send");
                             $('#error1').hide();
                         }
+                          setTimeout(function(){
+                                $('#emailsuccess').hide();
+                            }, 3000);
+                            setTimeout(function(){
+                                $('#successMessage1').hide();
+                            }, 3000);
+                            setTimeout(function(){
+                                $('#successMessage2').hide();
+                            }, 3000);
                     },
                     error: function (ex) {
                         $("#sendOtp").attr('disabled',false);
@@ -1420,9 +1435,12 @@ Sign in or Register
                             sessionStorage.setItem('oldenumber',numberverify);
                             verifyForm.elements['email_password'].value = $('#password').val();
                             $("#register").html("Register");
-                            /*setTimeout(function(){
+                            setTimeout(function(){
                                 $('#alertMessage1').hide();
-                            }, 3000);*/
+                            }, 3000);
+                             setTimeout(function(){
+                                $('#successMessage1').hide();
+                            }, 3000);
                         }
                     },
                     error: function (data) {

--- a/resources/views/themes/default1/front/auth/login-register.blade.php
+++ b/resources/views/themes/default1/front/auth/login-register.blade.php
@@ -601,7 +601,7 @@ Sign in or Register
             $('#enterotp').hide();
             if(verify_otp_check()) {
                 $("#verifyOtp").attr('disabled',true);
-                $("#verifyOtp").html("<i class='fa fa-circle-o-notch fa-spin fa-1x fa-fw'></i>Verifying...");
+                // $("#verifyOtp").html("<i class='fa fa-circle-o-notch fa-spin fa-1x fa-fw'></i>Verifying...");
                 var data = {
                     "mobile":   $('#verify_number').val().replace(/[\. ,:-]+/g, ''),
                     "code"  :   $('#verify_country_code').val(),
@@ -627,6 +627,9 @@ Sign in or Register
                         setTimeout(()=>{
                             getLoginTab();
                         },10)
+                        setTimeout(function() {
+                            location.reload();
+                        }, 3000);
                     },
                     error: function (xhr, textStatus, errorThrown) {
                         $("#verifyOtp").attr('disabled',false);
@@ -634,7 +637,7 @@ Sign in or Register
                          var myJSON = xhr.responseJSON.message;
                          console.log(myJSON);
                          console.log(xhr);
-                        var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><br><ul>';
+                        var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><ul>';
                               for (var key in xhr.responseJSON.errors)
                         {
                             html += '<li>' + xhr.responseJSON.errors[key][0] + '</li>'
@@ -643,7 +646,7 @@ Sign in or Register
                         }
                         else{
                         var myJSON = JSON.parse(xhr.responseText);
-                        var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><br><ul>';
+                        var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><ul>';
                         $("#verifyOtp").html("Verify OTP");
                         for (var key in myJSON)
                         {

--- a/resources/views/themes/default1/front/auth/login-register.blade.php
+++ b/resources/views/themes/default1/front/auth/login-register.blade.php
@@ -628,9 +628,21 @@ Sign in or Register
                             getLoginTab();
                         },10)
                     },
-                    error: function (ex) {
+                    error: function (xhr, textStatus, errorThrown) {
                         $("#verifyOtp").attr('disabled',false);
-                        var myJSON = JSON.parse(ex.responseText);
+                        if (xhr.status === 422) {
+                         var myJSON = xhr.responseJSON.message;
+                         console.log(myJSON);
+                         console.log(xhr);
+                        var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><br><ul>';
+                              for (var key in xhr.responseJSON.errors)
+                        {
+                            html += '<li>' + xhr.responseJSON.errors[key][0] + '</li>'
+                        }
+                        html += '</ul></div>';
+                        }
+                        else{
+                        var myJSON = JSON.parse(xhr.responseText);
                         var html = '<div class="alert alert-danger"><strong>Whoops! </strong>Something went wrong<br><br><ul>';
                         $("#verifyOtp").html("Verify OTP");
                         for (var key in myJSON)
@@ -638,6 +650,8 @@ Sign in or Register
                             html += '<li>' + myJSON[key][0] + '</li>'
                         }
                         html += '</ul></div>';
+                 
+                        }
                         $('#successMessage2').hide();
                         $('#alertMessage2').hide();
                         $('#error2').show();


### PR DESCRIPTION
resolves https://github.com/ladybirdweb/agora-invoicing-community/issues/1984

There are several ways we could get this exception for example:

An empty string is NOT numeric
Space between mobile number is NOT numeric
Contains any special characters in mobile number is NOT numeric

In php 7
'123456789 ' is NOT numeric

Generally It is not advisable to use numeric in phone numbers.