### PR TITLE
Remember me Fixed

### DIFF
--- a/resources/views/themes/default1/front/auth/login-register.blade.php
+++ b/resources/views/themes/default1/front/auth/login-register.blade.php
@@ -192,8 +192,7 @@ foreach($scripts as $script) {
 
                                 <div class="custom-control custom-checkbox" style="padding-right: 100px;">
 
-                                    <input type="checkbox" class="custom-control-input" id="rememberme">
-
+                                    {!! Form::checkbox('remember', '1', false, ['class' => 'custom-control-input', 'id' => 'rememberme']) !!}
                                     <label class="form-label custom-control-label cur-pointer text-2" for="rememberme">Remember Me</label>
                                 </div>
                             </div>


### PR DESCRIPTION
We have identified an issue with the session configuration in our system that requires prompt attention. To facilitate a quick and efficient testing process, kindly follow the steps outlined below:

1. Navigate to the file `config/session.php` within the application.

2. Locate the line:
   ```php
   'lifetime' => env('SESSION_LIFETIME', 120),
   ```

3. Change the value `120` to `1`:
   ```php
   'lifetime' => env('SESSION_LIFETIME', 1),
   ```

This modification is essential for testing the behavior of our system in scenarios where the "Remember Me" option is not selected. Following this adjustment, the system will automatically log users out after one minute if they close the tab without selecting the "Remember Me" option during login. Conversely, if the "Remember Me" option is checked, the session will persist for a longer duration.